### PR TITLE
Add history page for recent picks

### DIFF
--- a/history.html
+++ b/history.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Recent SuperLotto Picks</title>
+    <style>
+      :root {
+        --cat-size: 240px;
+      }
+      body {
+        font-family: Arial, sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        min-height: 100vh;
+        margin: 0;
+        padding: 20px;
+        background: linear-gradient(#22004c, #3f007f);
+        color: #e9d7ff;
+      }
+      .container {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background: rgba(48, 25, 71, 0.95);
+        border-radius: 16px;
+        box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+        padding: 24px;
+        max-width: 640px;
+        width: 100%;
+        color: #e9d7ff;
+      }
+      h2 {
+        margin: 0;
+        color: #f0e8ff;
+        text-align: center;
+      }
+      p {
+        margin-top: 8px;
+        margin-bottom: 16px;
+        color: #d1b6f2;
+        text-align: center;
+      }
+      .status {
+        font-style: italic;
+      }
+      .history-list {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        width: 100%;
+      }
+      .history-item {
+        background: rgba(63, 27, 97, 0.75);
+        border-radius: 12px;
+        padding: 16px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+      }
+      .history-item h3 {
+        margin: 0 0 8px;
+        font-size: 18px;
+        color: #f5e3ff;
+      }
+      .numbers {
+        margin-top: 12px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        gap: 10px;
+      }
+      .number-ball {
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: bold;
+        font-size: 18px;
+        color: #ffffff;
+        background: #7e56da;
+      }
+      .mega-ball {
+        background: #bb65c8;
+      }
+      .meta {
+        margin-top: 8px;
+        font-size: 13px;
+        color: #bda3e6;
+        text-align: left;
+      }
+      .button {
+        margin-top: 24px;
+        padding: 12px 24px;
+        border: none;
+        border-radius: 12px;
+        background: #7e56da;
+        color: #ffffff;
+        cursor: pointer;
+        font-size: 16px;
+        transition: background 0.3s;
+      }
+      .button:hover {
+        background: #916ce0;
+      }
+      @media (max-width: 480px) {
+        .number-ball {
+          width: 40px;
+          height: 40px;
+          font-size: 16px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h2>Recent SuperLotto Picks</h2>
+      <p class="intro">The last 20 draws recorded by the mystic cat.</p>
+      <p id="status" class="status" role="status">Loading recent picks…</p>
+      <div id="history-list" class="history-list" aria-live="polite"></div>
+      <button id="back-btn" class="button">Back to Picker</button>
+    </div>
+    <script>
+      const API_URL = "https://d2zi62cpjup4kp.cloudfront.net/api/entries?limit=20";
+      const statusEl = document.getElementById("status");
+      const historyList = document.getElementById("history-list");
+
+      async function loadHistory() {
+        try {
+          const response = await fetch(API_URL, { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const data = await response.json();
+          renderHistory(Array.isArray(data.items) ? data.items : []);
+        } catch (err) {
+          statusEl.textContent = "Unable to load picks right now. Please try again later.";
+          console.error("Failed to load history", err);
+        }
+      }
+
+      function formatDate(value) {
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return value;
+        }
+        try {
+          return date.toLocaleString(undefined, {
+            dateStyle: "medium",
+            timeStyle: "short",
+          });
+        } catch (e) {
+          return date.toLocaleString();
+        }
+      }
+
+      function renderHistory(items) {
+        historyList.innerHTML = "";
+        if (!items.length) {
+          statusEl.textContent = "No previous picks have been recorded yet.";
+          return;
+        }
+        statusEl.textContent = "";
+        const sorted = [...items].sort((a, b) => {
+          const timeA = new Date(a.pickedAt).getTime();
+          const timeB = new Date(b.pickedAt).getTime();
+          if (Number.isNaN(timeA) || Number.isNaN(timeB)) {
+            return 0;
+          }
+          return timeB - timeA;
+        });
+
+        sorted.forEach((entry, index) => {
+          const card = document.createElement("article");
+          card.className = "history-item";
+
+          const heading = document.createElement("h3");
+          heading.textContent = `${index + 1}. ${formatDate(entry.pickedAt)}`;
+          card.appendChild(heading);
+
+          const numbersWrap = document.createElement("div");
+          numbersWrap.className = "numbers";
+          (entry.picks || []).forEach((pick) => {
+            const ball = document.createElement("span");
+            ball.className = "number-ball";
+            if (pick.IsSpecial) {
+              ball.classList.add("mega-ball");
+            }
+            ball.textContent = pick.Number;
+            numbersWrap.appendChild(ball);
+          });
+          card.appendChild(numbersWrap);
+
+          if (entry.meta) {
+            const metaParts = [];
+            if (entry.meta.sourceIp) {
+              metaParts.push(`from ${entry.meta.sourceIp}`);
+            }
+            if (entry.meta.userAgent) {
+              metaParts.push(`via ${entry.meta.userAgent}`);
+            }
+            if (metaParts.length) {
+              const meta = document.createElement("div");
+              meta.className = "meta";
+              meta.textContent = `Picked ${metaParts.join(" ")}`;
+              card.appendChild(meta);
+            }
+          }
+
+          historyList.appendChild(card);
+        });
+      }
+
+      document.getElementById("back-btn").addEventListener("click", () => {
+        window.location.href = "index.html";
+      });
+
+      loadHistory();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,31 @@
       .button:hover {
         background: #916ce0;
       }
+      .button.secondary {
+        background: #5440a3;
+      }
+      .button.secondary:hover {
+        background: #6654b8;
+      }
+      .button-row {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
+        width: 100%;
+      }
+      .button-row .button {
+        margin-top: 0;
+      }
+      @media (min-width: 480px) {
+        .button-row {
+          flex-direction: row;
+          justify-content: center;
+        }
+        .button-row .button {
+          flex: 1;
+        }
+      }
       .numbers {
         margin-top: 24px;
         display: flex;
@@ -174,7 +199,10 @@
         </div>
         <h2>SuperLotto Plus Picker</h2>
         <p id="instructions"></p>
-        <button id="pick-btn" class="button">Generate Numbers</button>
+        <div class="button-row">
+          <button id="pick-btn" class="button">Generate Numbers</button>
+          <button id="history-btn" class="button secondary">View Recent Picks</button>
+        </div>
         <div id="numbers" class="numbers"></div>
       </div>
     <script>
@@ -256,6 +284,12 @@
       document
         .getElementById("pick-btn")
         .addEventListener("click", generateNumbers);
+
+      document
+        .getElementById("history-btn")
+        .addEventListener("click", () => {
+          window.location.href = "history.html";
+        });
 
       const mystic = (() => {
         const svg = d3.select("#mystic-board");


### PR DESCRIPTION
## Summary
- add a secondary navigation button on the picker page that links to a new history view
- create a history page that fetches the most recent 20 API entries and displays their numbers and metadata in styled cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce4df35738832ea23a243c2bcfaa9e