### PR TITLE
Add detail view for stored picks

### DIFF
--- a/details.html
+++ b/details.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Entry Details</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="app.js" defer></script>
+  </head>
+  <body class="detail-page">
+    <div class="container">
+      <h2>Entry Details</h2>
+      <p class="intro">A closer look at one of the mystic cat's recorded picks.</p>
+      <p id="status" class="status" role="status">Waiting for entry key...</p>
+      <div id="entry-detail" class="history-list single" aria-live="polite"></div>
+      <a
+        id="raw-link"
+        class="raw-link hidden"
+        href="#"
+        target="_blank"
+        rel="noopener noreferrer"
+        >View raw JSON</a
+      >
+      <div class="button-row">
+        <button id="history-back-btn" class="button secondary">Back to History</button>
+        <button id="home-btn" class="button">Back to Picker</button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/history.html
+++ b/history.html
@@ -9,7 +9,10 @@
   <body class="history-page">
     <div class="container">
       <h2>Recent SuperLotto Picks</h2>
-      <p class="intro">The last 20 draws recorded by the mystic cat.</p>
+      <p class="intro">
+        The last 20 draws recorded by the mystic cat. Select <strong>Details</strong> to
+        inspect a specific pick.
+      </p>
       <p id="status" class="status" role="status">Loading recent picks...</p>
       <div id="history-list" class="history-list" aria-live="polite"></div>
       <button id="back-btn" class="button">Back to Picker</button>

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,11 @@ body {
   overflow: visible;
 }
 
+.detail-page .container {
+  max-width: 640px;
+  overflow: visible;
+}
+
 h2 {
   margin: 0;
   color: #f0e8ff;
@@ -78,6 +83,12 @@ p {
 
 .button.secondary:hover {
   background: #6654b8;
+}
+
+.button:disabled,
+.button[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .button-row {
@@ -242,6 +253,10 @@ p {
   width: 100%;
 }
 
+.history-list.single {
+  gap: 0;
+}
+
 .history-item {
   background: rgba(63, 27, 97, 0.75);
   border-radius: 12px;
@@ -268,4 +283,30 @@ p {
   font-size: 13px;
   color: #bda3e6;
   text-align: left;
+}
+
+.card-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.card-actions .button {
+  margin-top: 0;
+}
+
+.raw-link {
+  margin-top: 16px;
+  color: #c8b4ff;
+  text-decoration: underline;
+  font-size: 13px;
+  align-self: flex-start;
+}
+
+.raw-link:hover {
+  color: #e2d8ff;
+}
+
+.hidden {
+  display: none !important;
 }


### PR DESCRIPTION
## Summary
- add shared helpers for formatting and entry card rendering across pages
- add a details action on history entries that links to a new entry details page
- style the new details view and surface a link to the raw JSON payload when available

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf38b245e4832eba6bd3dc0d7a0397