### PR TITLE
Add mystic board visualizations to history entries

### DIFF
--- a/history.html
+++ b/history.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Recent SuperLotto Picks</title>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
     <link rel="stylesheet" href="styles.css" />
     <script src="app.js" defer></script>
   </head>

--- a/styles.css
+++ b/styles.css
@@ -247,6 +247,28 @@ p {
   border-radius: 12px;
   padding: 16px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.history-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1 1 auto;
+}
+
+.history-board-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.history-board {
+  width: 140px;
+  height: 140px;
+  display: block;
 }
 
 .history-item h3 {
@@ -256,7 +278,7 @@ p {
 }
 
 .history-item .numbers {
-  margin-top: 12px;
+  margin-top: 0;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
@@ -264,8 +286,28 @@ p {
 }
 
 .meta {
-  margin-top: 8px;
+  margin-top: 0;
   font-size: 13px;
   color: #bda3e6;
   text-align: left;
+}
+
+@media (min-width: 560px) {
+  .history-item {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .history-board-wrapper {
+    flex: 0 0 auto;
+    margin-left: auto;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 480px) {
+  .history-board {
+    width: 120px;
+    height: 120px;
+  }
 }


### PR DESCRIPTION
## Summary
- extract the mystic board renderer so it can be reused outside the picker view
- render a compact mystic board beside each stored pick in the history list and load d3 on that page
- refresh the history card layout to accommodate the new visualization

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf980651e4832eaee764a6e964529e