### PR TITLE
Add special ball visualization to mystic board

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,11 +144,11 @@
       );
 
       const R = w * 0.5;
-      const rNode = Math.max(2, w * 0.006);
+      const rNode = Math.max(2, w * 0.005);
 
       const special = sanitizeSpecial(specialPick, limit ?? totalPositions);
       const glowAllowance = Math.max(4, w * 0.01);
-      const circlePadding = Math.max(1.5, w * 0.003);
+      const circlePadding = Math.max(1.2, w * 0.003);
       const specialOffset = glowAllowance + circlePadding;
 
       g.append("circle")

--- a/app.js
+++ b/app.js
@@ -147,6 +147,9 @@
       const rNode = Math.max(2, w * 0.006);
 
       const special = sanitizeSpecial(specialPick, limit ?? totalPositions);
+      const glowAllowance = Math.max(4, w * 0.01);
+      const circlePadding = Math.max(1.5, w * 0.003);
+      const specialOffset = glowAllowance + circlePadding;
 
       g.append("circle")
         .attr("r", R)
@@ -213,17 +216,25 @@
       if (special) {
         const specialAngle =
           ((special.value - 1) / special.limit) * Math.PI * 2 - Math.PI / 2;
-        const [sx, sy] = polarToXY(specialAngle, R);
-        g.append("circle")
-          .attr("class", "special-node")
-          .attr("cx", sx)
-          .attr("cy", sy)
-          .attr("r", Math.max(rNode * 1.8, w * 0.012))
-          .attr("fill", "#ff4d6d")
-          .attr("stroke", "#ffffff")
-          .attr("stroke-width", Math.max(1, w * 0.0025))
-          .attr("opacity", 0.95)
-          .attr("filter", "url(#glow)");
+        let specialRadius = Math.max(rNode * 1.8, w * 0.012);
+        const maxSpecialRadius = Math.max(0, R - specialOffset);
+        if (specialRadius > maxSpecialRadius) {
+          specialRadius = maxSpecialRadius;
+        }
+        if (specialRadius > 0) {
+          const specialOrbit = Math.max(R - (specialRadius + specialOffset), 0);
+          const [sx, sy] = polarToXY(specialAngle, specialOrbit);
+          g.append("circle")
+            .attr("class", "special-node")
+            .attr("cx", sx)
+            .attr("cy", sy)
+            .attr("r", specialRadius)
+            .attr("fill", "#ff4d6d")
+            .attr("stroke", "#ffffff")
+            .attr("stroke-width", Math.max(1, w * 0.0025))
+            .attr("opacity", 0.95)
+            .attr("filter", "url(#glow)");
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- extend the mystic board renderer to support drawing an optional special/power ball
- highlight the special ball with a brighter, larger node for picker and history boards

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d03859e790832eb5d0ea449c53aa78