### PR TITLE
Remove metadata display from history cards

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -524,22 +524,6 @@
         });
         content.appendChild(numbersWrap);
 
-        if (entry.meta) {
-          const metaParts = [];
-          if (entry.meta.sourceIp) {
-            metaParts.push(`from ${entry.meta.sourceIp}`);
-          }
-          if (entry.meta.userAgent) {
-            metaParts.push(`via ${entry.meta.userAgent}`);
-          }
-          if (metaParts.length) {
-            const meta = document.createElement("div");
-            meta.className = "meta";
-            meta.textContent = `Picked ${metaParts.join(" ")}`;
-            content.appendChild(meta);
-          }
-        }
-
         const vizWrapper = document.createElement("div");
         vizWrapper.className = "history-board-wrapper";
         const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -285,13 +285,6 @@ p {
   gap: 10px;
 }
 
-.meta {
-  margin-top: 0;
-  font-size: 13px;
-  color: #bda3e6;
-  text-align: left;
-}
-
 @media (min-width: 560px) {
   .history-item {
     flex-direction: row;


### PR DESCRIPTION
## Summary
- stop rendering stored metadata like source IP and user agent on history cards
- remove the unused style block that targeted the metadata text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d22a97ef08832ea98fd1e297aa0859