### PR TITLE
Add played toggle controls to history entries

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -595,7 +595,17 @@
         return "";
       }
 
-      return segments.map((segment) => encodeURIComponent(segment)).join("/");
+      let normalizedSegments = segments;
+      if (segments.length > 1 && segments[0].toLowerCase() === "entries") {
+        normalizedSegments = segments.slice(1);
+        if (!normalizedSegments.length) {
+          normalizedSegments = segments;
+        }
+      }
+
+      return normalizedSegments
+        .map((segment) => encodeURIComponent(segment))
+        .join("/");
     }
 
     async function updatePlayedStateRequest(entryId, playedValue) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,63 @@
   const MAIN_COUNT = 5;
   const MAIN_MAX = 47;
   const MEGA_MAX = 27;
+  const API_BASE_URL = "https://d2zi62cpjup4kp.cloudfront.net/api/entries";
+
+  // Optionally attach an API key header if one has been provided via markup or storage.
+  function getOptionalApiKeyHeaders() {
+    let key = null;
+
+    try {
+      if (typeof document !== "undefined") {
+        const metaKey = document
+          .querySelector('meta[name="lotto-api-key"]')
+          ?.getAttribute("content");
+        if (metaKey && metaKey.trim()) {
+          key = metaKey.trim();
+        } else if (document.body?.dataset?.apiKey) {
+          const bodyKey = document.body.dataset.apiKey.trim();
+          if (bodyKey) {
+            key = bodyKey;
+          }
+        }
+      }
+    } catch (err) {
+      // Access to DOM metadata may be restricted; ignore and continue.
+    }
+
+    if (!key) {
+      try {
+        if (typeof window !== "undefined" && window.localStorage) {
+          const storedKey = window.localStorage.getItem("lottoApiKey");
+          if (storedKey && storedKey.trim()) {
+            key = storedKey.trim();
+          }
+        }
+      } catch (err) {
+        // Access to localStorage may be blocked (e.g., privacy mode).
+      }
+    }
+
+    if (!key) {
+      try {
+        if (typeof window !== "undefined" && window.sessionStorage) {
+          const sessionKey = window.sessionStorage.getItem("lottoApiKey");
+          if (sessionKey && sessionKey.trim()) {
+            key = sessionKey.trim();
+          }
+        }
+      } catch (err) {
+        // Access to sessionStorage may be blocked.
+      }
+    }
+
+    if (typeof key === "string" && key.trim()) {
+      return { "x-api-key": key.trim() };
+    }
+
+    return {};
+  }
+
 
   document.addEventListener("DOMContentLoaded", () => {
     const body = document.body;
@@ -242,7 +299,7 @@
   }
 
   function initPickerPage() {
-    const STORE_API_URL = "https://d2zi62cpjup4kp.cloudfront.net/api/entries";
+    const STORE_API_URL = API_BASE_URL;
 
     const instructionsEl = document.getElementById("instructions");
     const pickBtn = document.getElementById("pick-btn");
@@ -382,6 +439,7 @@
           headers: {
             "Content-Type": "application/json",
             Accept: "application/json",
+            ...getOptionalApiKeyHeaders(),
           },
           body: JSON.stringify(payload),
         });
@@ -407,6 +465,7 @@
           method: "POST",
           headers: {
             Accept: "application/json",
+            ...getOptionalApiKeyHeaders(),
           },
           body: JSON.stringify(payload),
         });
@@ -444,7 +503,7 @@
   }
 
   function initHistoryPage() {
-    const API_URL = "https://d2zi62cpjup4kp.cloudfront.net/api/entries?limit=20";
+    const API_URL = `${API_BASE_URL}?limit=20`;
     const statusEl = document.getElementById("status");
     const historyList = document.getElementById("history-list");
     const backBtn = document.getElementById("back-btn");
@@ -454,17 +513,169 @@
       return;
     }
 
+    function fetchWithTimeout(resource, options = {}, timeoutMs = 12000) {
+      const controller = new AbortController();
+      const timerId = setTimeout(() => controller.abort(), timeoutMs);
+      const mergedOptions = {
+        mode: "cors",
+        cache: "no-store",
+        credentials: "omit",
+        ...options,
+        signal: controller.signal,
+      };
+      return fetch(resource, mergedOptions).finally(() => clearTimeout(timerId));
+    }
+
+    function coerceBoolean(value) {
+      if (value === null || value === undefined) {
+        return false;
+      }
+      if (typeof value === "boolean") {
+        return value;
+      }
+      if (typeof value === "number") {
+        return value !== 0;
+      }
+      if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) {
+          return false;
+        }
+        if (["true", "1", "yes", "y"].includes(normalized)) {
+          return true;
+        }
+        if (["false", "0", "no", "n"].includes(normalized)) {
+          return false;
+        }
+        return Boolean(normalized);
+      }
+      return Boolean(value);
+    }
+
+    function getPlayedState(entry) {
+      if (!entry || typeof entry !== "object") {
+        return false;
+      }
+      const candidates = [
+        "played",
+        "Played",
+        "isPlayed",
+        "IsPlayed",
+        "wasPlayed",
+        "WasPlayed",
+      ];
+      for (const prop of candidates) {
+        if (prop in entry) {
+          return coerceBoolean(entry[prop]);
+        }
+      }
+      const nested = [entry.meta, entry.metadata, entry.state, entry.details];
+      for (const candidate of nested) {
+        if (candidate && typeof candidate === "object") {
+          if ("played" in candidate) {
+            return coerceBoolean(candidate.played);
+          }
+          if ("Played" in candidate) {
+            return coerceBoolean(candidate.Played);
+          }
+        }
+      }
+      return false;
+    }
+
+    function getEntryId(entry) {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+      const candidates = [
+        entry.id,
+        entry.ID,
+        entry.entryId,
+        entry.EntryId,
+        entry.entryID,
+        entry.key,
+        entry.Key,
+        entry.pk,
+        entry.PK,
+        entry.sk,
+        entry.SK,
+        entry.s3Key,
+        entry.S3Key,
+        entry.filename,
+        entry.fileName,
+        entry.name,
+        entry.uri,
+        entry.URL,
+      ];
+      for (const candidate of candidates) {
+        if (candidate === null || candidate === undefined) {
+          continue;
+        }
+        const text = String(candidate).trim();
+        if (text) {
+          return text;
+        }
+      }
+      if (typeof entry.location === "string" && entry.location.trim()) {
+        return entry.location.trim();
+      }
+      return null;
+    }
+
+    function normalizeEntryId(entryId) {
+      if (entryId === null || entryId === undefined) {
+        return "";
+      }
+      const text = String(entryId).trim();
+      if (!text) {
+        return "";
+      }
+      try {
+        return encodeURIComponent(decodeURIComponent(text));
+      } catch (err) {
+        return encodeURIComponent(text);
+      }
+    }
+
+    async function updatePlayedStateRequest(entryId, playedValue) {
+      const normalizedId = normalizeEntryId(entryId);
+      if (!normalizedId) {
+        throw new Error("Missing or invalid entry identifier");
+      }
+      const targetUrl = `${API_BASE_URL}/${normalizedId}/played/${playedValue ? "true" : "false"}`;
+      const response = await fetchWithTimeout(targetUrl, {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          ...getOptionalApiKeyHeaders(),
+        },
+      });
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+          `Request failed with status ${response.status}${body ? `: ${body}` : ""}`
+        );
+      }
+    }
+
     async function loadHistory() {
       try {
-        const response = await fetch(API_URL, { cache: "no-store" });
+        const response = await fetchWithTimeout(API_URL, {
+          headers: {
+            Accept: "application/json",
+            ...getOptionalApiKeyHeaders(),
+          },
+        });
         if (!response.ok) {
           throw new Error(`Request failed with status ${response.status}`);
         }
         const data = await response.json();
         renderHistory(Array.isArray(data.items) ? data.items : []);
+        return true;
       } catch (err) {
         statusEl.textContent = "Unable to load picks right now. Please try again later.";
         console.error("Failed to load history", err);
+        return false;
       }
     }
 
@@ -523,6 +734,73 @@
           numbersWrap.appendChild(ball);
         });
         content.appendChild(numbersWrap);
+
+        const metaRow = document.createElement("div");
+        metaRow.className = "history-meta";
+
+        const playedIndicator = document.createElement("span");
+        playedIndicator.className = "history-played-state";
+        metaRow.appendChild(playedIndicator);
+
+        const toggleBtn = document.createElement("button");
+        toggleBtn.type = "button";
+        toggleBtn.className = "button small history-played-toggle";
+        metaRow.appendChild(toggleBtn);
+
+        const entryId = getEntryId(entry);
+        const initialPlayed = getPlayedState(entry);
+
+        const applyPlayedUi = (value) => {
+          const isPlayed = Boolean(value);
+          playedIndicator.textContent = `Played: ${isPlayed ? "true" : "false"}`;
+          playedIndicator.classList.toggle("is-true", isPlayed);
+          playedIndicator.classList.toggle("is-false", !isPlayed);
+          toggleBtn.textContent = isPlayed ? "Mark as unplayed" : "Mark as played";
+          toggleBtn.setAttribute("aria-pressed", isPlayed ? "true" : "false");
+        };
+
+        applyPlayedUi(initialPlayed);
+
+        if (!entryId) {
+          toggleBtn.disabled = true;
+          toggleBtn.textContent = "ID unavailable";
+          toggleBtn.title = "Unable to update without an entry identifier.";
+          toggleBtn.setAttribute("aria-disabled", "true");
+        } else {
+          toggleBtn.addEventListener("click", async () => {
+            const current = getPlayedState(entry);
+            const nextValue = !current;
+            statusEl.textContent = "Updating entry...";
+            toggleBtn.disabled = true;
+            toggleBtn.textContent = "Updating...";
+            toggleBtn.setAttribute("aria-busy", "true");
+            try {
+              await updatePlayedStateRequest(entryId, nextValue);
+            } catch (err) {
+              console.error("Failed to update played state", err);
+              statusEl.textContent =
+                "Unable to update the played state right now. Please try again later.";
+              toggleBtn.disabled = false;
+              toggleBtn.removeAttribute("aria-busy");
+              toggleBtn.removeAttribute("aria-disabled");
+              applyPlayedUi(current);
+              return;
+            }
+
+            const reloadSucceeded = await loadHistory();
+            if (reloadSucceeded) {
+              return;
+            }
+            statusEl.textContent =
+              "Played state updated, but the history view could not be refreshed. Please reload.";
+            toggleBtn.disabled = false;
+            toggleBtn.removeAttribute("aria-busy");
+            toggleBtn.removeAttribute("aria-disabled");
+            applyPlayedUi(nextValue);
+          });
+        }
+
+        content.appendChild(metaRow);
 
         const vizWrapper = document.createElement("div");
         vizWrapper.className = "history-board-wrapper";

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -406,9 +406,7 @@
       try {
         const resp2 = await fetchWithTimeout(STORE_API_URL, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-          },
+      
           body: JSON.stringify(payload),
         });
         if (!resp2.ok) {

--- a/frontend/history.html
+++ b/frontend/history.html
@@ -10,7 +10,10 @@
   <body class="history-page">
     <div class="container">
       <h2>Recent SuperLotto Picks</h2>
-      <p class="intro">The last 20 draws recorded by the amazing mystic cat.</p>
+      <p class="intro">
+        The last 20 draws recorded by the amazing mystic cat. Toggle the played state to keep
+        track of which picks you've used.
+      </p>
       <p id="status" class="status" role="status">Loading recent picks...</p>
       <div id="history-list" class="history-list" aria-live="polite"></div>
       <button id="back-btn" class="button">Back to Picker</button>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -72,12 +72,23 @@ p {
   background: #916ce0;
 }
 
+.button:disabled,
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .button.secondary {
   background: #5440a3;
 }
 
 .button.secondary:hover {
   background: #6654b8;
+}
+
+.button.small {
+  padding: 8px 16px;
+  font-size: 14px;
 }
 
 .button-row {
@@ -250,6 +261,46 @@ p {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.history-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.history-meta .button {
+  margin-top: 0;
+}
+
+.history-played-state {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(126, 86, 218, 0.35);
+  color: #f5e3ff;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+}
+
+.history-played-state.is-true {
+  background: rgba(64, 168, 122, 0.35);
+  color: #c7ffdc;
+}
+
+.history-played-state.is-false {
+  background: rgba(217, 109, 140, 0.35);
+  color: #ffe3f1;
+}
+
+.history-played-toggle[aria-busy="true"] {
+  cursor: progress;
 }
 
 .history-content {

--- a/readme.md
+++ b/readme.md
@@ -11,21 +11,6 @@ Preview (S3 object URL):
 - No build required. Open `frontend/index.html` directly in your browser.
 - Optional: run a simple static server while editing to avoid caching quirks.
 
-### API key for protected API routes
-Some API Gateway routes (e.g., marking a pick as played) may require an API key. The front-end
-looks for the key in a few non-secret storage spots and, when available, sends it as an `x-api-key`
-header on requests:
-
-- A `<meta name="lotto-api-key" content="VALUE" />` tag in the page head
-- A `data-api-key="VALUE"` attribute on the `<body>` element
-- `localStorage.setItem("lottoApiKey", "VALUE")`
-- `sessionStorage.setItem("lottoApiKey", "VALUE")`
-
-Pick whichever option best fits your hosting setup (e.g., run `localStorage.setItem(...)` in the
-browser console after loading the page).
-
----
-
 ## Quick deploy to S3
 Prereqs:
 - AWS CLI installed and configured with an IAM user that can write to `s3://lotto.robstave.com`

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,19 @@ Preview (S3 object URL):
 - No build required. Open `frontend/index.html` directly in your browser.
 - Optional: run a simple static server while editing to avoid caching quirks.
 
+### API key for protected API routes
+Some API Gateway routes (e.g., marking a pick as played) may require an API key. The front-end
+looks for the key in a few non-secret storage spots and, when available, sends it as an `x-api-key`
+header on requests:
+
+- A `<meta name="lotto-api-key" content="VALUE" />` tag in the page head
+- A `data-api-key="VALUE"` attribute on the `<body>` element
+- `localStorage.setItem("lottoApiKey", "VALUE")`
+- `sessionStorage.setItem("lottoApiKey", "VALUE")`
+
+Pick whichever option best fits your hosting setup (e.g., run `localStorage.setItem(...)` in the
+browser console after loading the page).
+
 ---
 
 ## Quick deploy to S3


### PR DESCRIPTION
## Summary
- add optional API key header support for API requests
- display each entry's played state in history and allow toggling via the new PUT endpoint
- style the played-state badge/button and document how to supply the API key for protected routes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d243f97d04832eb8bc74996ad34d06